### PR TITLE
Allow upvalues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog; Kong Serverless Functions Plugin
 
+## Unreleased
+
+- Functions can now have upvalues
+
 ## 0.2.0
 
 - Updated schemas to new format

--- a/kong/plugins/pre-function/_handler.lua
+++ b/kong/plugins/pre-function/_handler.lua
@@ -18,7 +18,9 @@ return function(plugin_name, priority)
     if not functions then
       functions = {}
       for _, fn_str in ipairs(config.functions) do
-        table.insert(functions, loadstring(fn_str))
+        local func1 = loadstring(fn_str)
+        local _, func2 = pcall(func1)
+        table.insert(functions, type(func2) == "function" and func2 or func1)
       end
       config_cache[config] = functions
     end

--- a/kong/plugins/pre-function/_schema.lua
+++ b/kong/plugins/pre-function/_schema.lua
@@ -5,12 +5,26 @@ return function(plugin_name)
 
 
   local function validate_function(fun)
-    local _, err = loadstring(fun)
+    local func1, err = loadstring(fun)
     if err then
       return false, "Error parsing " .. plugin_name .. ": " .. err
     end
 
-    return true
+    local success, func2 = pcall(func1)
+
+    if not success or func2 == nil then
+      -- the code IS the handler function
+      return true
+    end
+
+    -- the code RETURNED the handler function
+    if type(func2) == "function" then
+      return true
+    end
+
+    -- the code returned something unknown
+    return false, "Bad return value from " .. plugin_name .. " function, " ..
+                  "expected function type, got " .. type(func2)
   end
 
 

--- a/spec/02-schema_spec.lua
+++ b/spec/02-schema_spec.lua
@@ -1,8 +1,10 @@
 local v = require("spec.helpers").validate_plugin_config_schema
 
-local mock_fn_one = 'print("hello world!")'
+local mock_fn_one = '("hello world!"):find("world")'
 local mock_fn_two = 'local x = 1'
+local mock_fn_three = 'local x = 1 return function() x = x + 1 end'
 local mock_fn_invalid = 'print('
+local mock_fn_invalid_return = 'return "hello-world"'
 
 for _, plugin_name in ipairs({ "pre-function", "post-function" }) do
 
@@ -21,6 +23,13 @@ for _, plugin_name in ipairs({ "pre-function", "post-function" }) do
       assert.falsy(err)
     end)
 
+    it("validates single function with upvalues", function()
+      local ok, err = v({ functions = { mock_fn_three } }, schema)
+
+      assert.truthy(ok)
+      assert.falsy(err)
+    end)
+
     it("validates multiple functions", function()
       local ok, err = v({ functions = { mock_fn_one, mock_fn_two } }, schema)
 
@@ -34,6 +43,13 @@ for _, plugin_name in ipairs({ "pre-function", "post-function" }) do
 
         assert.falsy(ok)
         assert.equals("Error parsing " .. plugin_name .. ": [string \"print(\"]:1: unexpected symbol near '<eof>'", err.config.functions[1])
+      end)
+
+      it("with an invalid return value", function()
+        local ok, err = v({ functions = { mock_fn_invalid_return } }, schema)
+
+        assert.falsy(ok)
+        assert.equals("Bad return value from " .. plugin_name .. " function, expected function type, got string", err.config.functions[1])
       end)
 
       it("with a valid and invalid function", function()


### PR DESCRIPTION
This builds on top of #12 

Functions would just be executed upon each request. This PR allows functions to be executed when loaded, and RETURN a function that is called upon each request.

For example a simple request counter:

```lua
local count = 0

return function()
    count = count + 1
    print(count)
  end
```
