### PR TITLE
refactor(handler) no need to to inherit from BasePlugin anymore

### DIFF
--- a/kong/plugins/pre-function/_handler.lua
+++ b/kong/plugins/pre-function/_handler.lua
@@ -1,18 +1,17 @@
 -- handler file for both the pre-function and post-function plugin
 return function(plugin_name, priority)
-
-  local BasePlugin = require "kong.plugins.base_plugin"
-  local ServerlessFunction = BasePlugin:extend()
+  local loadstring = loadstring
+  local insert = table.insert
+  local ipairs = ipairs
 
   local config_cache = setmetatable({}, { __mode = "k" })
 
-  function ServerlessFunction:new()
-    ServerlessFunction.super.new(self, plugin_name)
-  end
-
+  local ServerlessFunction = {
+    PRIORITY = priority,
+    VERSION = "0.1.0",
+  }
 
   function ServerlessFunction:access(config)
-    ServerlessFunction.super.access(self)
 
     local functions = config_cache[config]
     if not functions then
@@ -20,7 +19,7 @@ return function(plugin_name, priority)
       for _, fn_str in ipairs(config.functions) do
         local func1 = loadstring(fn_str)
         local _, func2 = pcall(func1)
-        table.insert(functions, type(func2) == "function" and func2 or func1)
+        insert(functions, type(func2) == "function" and func2 or func1)
       end
       config_cache[config] = functions
     end
@@ -29,10 +28,6 @@ return function(plugin_name, priority)
       fn()
     end
   end
-
-
-  ServerlessFunction.PRIORITY = priority
-  ServerlessFunction.VERSION = "0.1.0"
 
 
   return ServerlessFunction

--- a/kong/plugins/pre-function/_schema.lua
+++ b/kong/plugins/pre-function/_schema.lua
@@ -2,6 +2,7 @@
 return function(plugin_name)
 
   local typedefs = require "kong.db.schema.typedefs"
+  local loadstring = loadstring
 
 
   local function validate_function(fun)


### PR DESCRIPTION
## Summary

Factored from #14; after merging previous PRs (#12 and #13), conflicts were introduced and parts of the then duplicated changes were no longer needed. After merging this, the corresponding commit in #14 can be dropped.