### PR TITLE
Fix for multiple invocations on initialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,6 @@ before_install:
 install:
   - luarocks make
   - cd kong-ce
-  # the following line is a hack to get around failing LuaSec upgrades
-  - luarocks remove luasec --force
   - make dev
   - createuser --createdb kong
   - createdb -U kong kong_tests

--- a/kong/plugins/pre-function/_handler.lua
+++ b/kong/plugins/pre-function/_handler.lua
@@ -14,14 +14,27 @@ return function(plugin_name, priority)
   function ServerlessFunction:access(config)
 
     local functions = config_cache[config]
+
     if not functions then
+      -- first call, go compile the functions
       functions = {}
       for _, fn_str in ipairs(config.functions) do
-        local func1 = loadstring(fn_str)
-        local _, func2 = pcall(func1)
-        insert(functions, type(func2) == "function" and func2 or func1)
+        local func1 = loadstring(fn_str)    -- load it
+        local _, func2 = pcall(func1)       -- run it
+        if type(func2) ~= "function" then
+          -- old style (0.1.0), without upvalues
+          insert(functions, func1)
+        else
+          -- this is a new function (0.2.0+), with upvalues
+          insert(functions, func2)
+
+          -- the first call to func1 above only initialized it, so run again
+          func2()
+        end
       end
+
       config_cache[config] = functions
+      return  -- must return since we allready executed them
     end
 
     for _, fn in ipairs(functions) do


### PR DESCRIPTION
When compiling the functions, the test that checks whether it is a plain function or a function with upvalues, would also execute the plugin.

This caused plain functions to run 2x on the first request.
