### PR TITLE
fix(schema) do not execute code on validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,39 +26,32 @@ services:
 
 env:
   global:
-    - LUAROCKS=2.4.3
-    - OPENSSL=1.0.2n
+    - PLUGIN_NAME=pre-function,post-function
+    - KONG_REPOSITORY=kong
+    - KONG_TAG=master
+    - KONG_PLUGINS=bundled,$PLUGIN_NAME
+    - KONG_TEST_PLUGINS=$KONG_PLUGINS
+    - LUAROCKS=3.2.1
+    - OPENSSL=1.1.1b
     - CASSANDRA_BASE=2.2.12
     - CASSANDRA_LATEST=3.9
-    - OPENRESTY_BASE=1.13.6.2
-    - OPENRESTY_LATEST=1.13.6.2
+    - OPENRESTY=1.15.8.1
     - DOWNLOAD_CACHE=$HOME/download-cache
     - INSTALL_CACHE=$HOME/install-cache
     - BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6"
-    - PLUGIN_NAME=pre-function,post-function
-    - KONG_TEST_CUSTOM_PLUGINS=$PLUGIN_NAME
-    - KONG_CUSTOM_PLUGINS=$PLUGIN_NAME
+    - TEST_FILE_PATH=$TRAVIS_BUILD_DIR/spec
 
   matrix:
-    - OPENRESTY=$OPENRESTY_BASE
-      CASSANDRA=$CASSANDRA_BASE
-    - OPENRESTY=$OPENRESTY_LATEST
-      CASSANDRA=$CASSANDRA_LATEST
-
-before_install:
-  - git clone https://$GITHUB_TOKEN:@github.com/Kong/kong-ci.git
-  - source kong-ci/setup_env.sh
-  - git clone --single-branch -b next https://github.com/Kong/kong.git kong-ce
+    - KONG_TEST_DATABASE=postgres
+    - KONG_TEST_DATABASE=cassandra CASSANDRA=$CASSANDRA_BASE
+    - KONG_TEST_DATABASE=cassandra CASSANDRA=$CASSANDRA_LATEST
 
 install:
-  - luarocks make
-  - cd kong-ce
-  - make dev
-  - createuser --createdb kong
-  - createdb -U kong kong_tests
+  - git clone --single-branch https://$GITHUB_TOKEN:@github.com/Kong/kong-ci ../kong-ci
+  - source ../kong-ci/setup_plugin_env.sh
 
 script:
-  - bin/busted $BUSTED_ARGS ../spec
+  - eval $BUSTED_CMD
 
 cache:
   apt: true

--- a/kong/plugins/pre-function/_schema.lua
+++ b/kong/plugins/pre-function/_schema.lua
@@ -8,24 +8,10 @@ return function(plugin_name)
   local function validate_function(fun)
     local func1, err = loadstring(fun)
     if err then
-      return false, "Error parsing " .. plugin_name .. ": " .. err
+      return false, "error parsing " .. plugin_name .. ": " .. err
     end
 
-    local success, func2 = pcall(func1)
-
-    if not success or func2 == nil then
-      -- the code IS the handler function
-      return true
-    end
-
-    -- the code RETURNED the handler function
-    if type(func2) == "function" then
-      return true
-    end
-
-    -- the code returned something unknown
-    return false, "Bad return value from " .. plugin_name .. " function, " ..
-                  "expected function type, got " .. type(func2)
+    return true
   end
 
 

--- a/spec/02-schema_spec.lua
+++ b/spec/02-schema_spec.lua
@@ -23,6 +23,17 @@ for _, plugin_name in ipairs({ "pre-function", "post-function" }) do
       assert.falsy(err)
     end)
 
+    it("error in function is not triggered during validation", function()
+      local ok, err = v({
+        functions = {
+          [[error("should never happen")]],
+        }
+      }, schema)
+
+      assert.truthy(ok)
+      assert.falsy(err)
+    end)
+
     it("validates single function with upvalues", function()
       local ok, err = v({ functions = { mock_fn_three } }, schema)
 
@@ -37,26 +48,26 @@ for _, plugin_name in ipairs({ "pre-function", "post-function" }) do
       assert.falsy(err)
     end)
 
+    it("a valid chunk with an invalid return type", function()
+      local ok, err = v({ functions = { mock_fn_invalid_return } }, schema)
+
+      assert.truthy(ok)
+      assert.falsy(err)
+    end)
+
     describe("errors", function()
       it("with an invalid function", function()
         local ok, err = v({ functions = { mock_fn_invalid } }, schema)
 
         assert.falsy(ok)
-        assert.equals("Error parsing " .. plugin_name .. ": [string \"print(\"]:1: unexpected symbol near '<eof>'", err.config.functions[1])
-      end)
-
-      it("with an invalid return value", function()
-        local ok, err = v({ functions = { mock_fn_invalid_return } }, schema)
-
-        assert.falsy(ok)
-        assert.equals("Bad return value from " .. plugin_name .. " function, expected function type, got string", err.config.functions[1])
+        assert.equals("error parsing " .. plugin_name .. ": [string \"print(\"]:1: unexpected symbol near '<eof>'", err.config.functions[1])
       end)
 
       it("with a valid and invalid function", function()
         local ok, err = v({ functions = { mock_fn_one, mock_fn_invalid } }, schema)
 
         assert.falsy(ok)
-        assert.equals("Error parsing " .. plugin_name .. ": [string \"print(\"]:1: unexpected symbol near '<eof>'", err.config.functions[2])
+        assert.equals("error parsing " .. plugin_name .. ": [string \"print(\"]:1: unexpected symbol near '<eof>'", err.config.functions[2])
       end)
     end)
   end)

--- a/spec/03-dbless_spec.lua
+++ b/spec/03-dbless_spec.lua
@@ -1,0 +1,57 @@
+local helpers = require "spec.helpers"
+
+
+for _, plugin_name in ipairs({ "pre-function", "post-function" }) do
+
+  describe("Plugin: " .. plugin_name .. " (dbless)", function()
+    local admin_client
+
+    setup(function()
+      assert(helpers.start_kong({
+        nginx_conf = "spec/fixtures/custom_nginx.template",
+        database = "off",
+      }))
+    end)
+
+    teardown(function()
+      helpers.stop_kong()
+    end)
+
+    before_each(function()
+      admin_client = helpers.admin_client()
+    end)
+
+    after_each(function()
+      if admin_client then
+        admin_client:close()
+      end
+    end)
+
+
+    describe("loading functions from declarative config", function()
+      it("does not execute the function ( https://github.com/kong/kong/issues/5110 )", function()
+        local res = assert(admin_client:send {
+          method = "POST",
+          path = "/config",
+          body = {
+            config = [[
+              "_format_version": "1.1"
+              plugins:
+              - name: "pre-function"
+                config:
+                  functions:
+                  - | 
+                      kong.log.err("foo")
+                      kong.response.exit(418)
+            ]]
+          },
+          headers = {
+            ["Content-type"] = "application/json"
+          }
+        })
+        assert.res_status(201, res)
+      end)
+    end)
+  end)
+
+end


### PR DESCRIPTION
Also, pcall every execution of arbitrary user code. Includes a regression test for Kong/kong#5110

An errors in the return type of the chunk will result in a runtime error like any other, which will be logged and returned as 500 to the client, as usual.

Fixes Kong/kong#5110.
Fixes #23 

edit: added the fix for #23 