### PR TITLE
chore(ci) update kong versions matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,20 @@ dist: bionic
 
 jobs:
   include:
-  - name: Kong CE 1.3.x
-    env: KONG_VERSION=1.3.x
-  - name: Kong CE 1.5.x
-    env: KONG_VERSION=1.5.x
-  - name: Kong CE 2.0.x
-    env: KONG_VERSION=2.0.x
-  - name: Kong Enterprise 1.3.0.x
-    env: KONG_VERSION=1.3.0.x
-  - name: Kong Enterprise 1.5.0.x
-    env: KONG_VERSION=1.5.0.x
-  - name: Kong Enterprise nightly
-    env: KONG_VERSION=nightly-ee
+  - name: Kong CE 2.2.x
+    env: KONG_VERSION=2.2.x
+  - name: Kong CE 2.3.x
+    env: KONG_VERSION=2.3.x
+  - name: Kong CE Master
+    env: KONG_VERSION=nightly
+  #- name: Kong EE 1.5.0.x      # pending resolution re
+  #  env: KONG_VERSION=1.5.0.x  #  https://github.com/Kong/kong-pongo/pull/147
+  #- name: Kong EE 2.1.4.x      # context: current EE images are out of date in Pongo
+  #  env: KONG_VERSION=2.1.4.x  # so they do not include required sandbox modules
+  #- name: Kong EE 2.2.1.x
+  #  env: KONG_VERSION=2.2.1.x
+  #- name: Kong Enterprise nightly
+  #  env: KONG_VERSION=nightly-ee
 
 env:
   global:


### PR DESCRIPTION
This PR updates the Kong versions matrix to:
- Remove old CE versions (< 2.2) that do not have the sandbox feature
- Override used EE images to their latest nightly, leveraging PR https://github.com/Kong/kong-pongo/pull/147

Pipeline is still not 100% green, EE 2.1 job is failing (reason still unknown - investigation ongoing); we should still merge this PR, as other jobs are green.